### PR TITLE
Bump aws-java-sdk dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.499</version>
+                <version>1.11.620</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Bump the aws-java-sdk dependency version (minor) as the old version already as a bunch of security issues.