### PR TITLE
Upgrade to AWS SDK v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -63,9 +63,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.666</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.10.56</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -83,8 +83,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/alex/mojaki/s3upload/MultiPartOutputStream.java
+++ b/src/main/java/alex/mojaki/s3upload/MultiPartOutputStream.java
@@ -6,7 +6,8 @@ import org.slf4j.LoggerFactory;
 import java.io.OutputStream;
 import java.util.concurrent.BlockingQueue;
 
-import static com.amazonaws.services.s3.internal.Constants.MB;
+import static alex.mojaki.s3upload.StreamTransferManager.MB;
+
 
 /**
  * An {@code OutputStream} which packages data written to it into discrete {@link StreamPart}s which can be obtained


### PR DESCRIPTION
Closes #23 

I took a stab at this, but pretty quickly lost interest. Upgrading the library code was straightforward, and it likely works now, but the tests are much harder. The test client requires all sorts of configuration tweaks to work with s3proxy and I don't know how to do that in the new version. If someone who knows more about this stuff could make the tests run, that'd be great. I don't even write Java these days.

In general the tests are hacky and could use an overhaul. There may be much better local S3 alternatives for this purpose than s3proxy. They also have poor coverage.