### PR TITLE
Fix #37 - use String.valueOf to protect against null uploadId in toString

### DIFF
--- a/src/main/java/alex/mojaki/s3upload/StreamTransferManager.java
+++ b/src/main/java/alex/mojaki/s3upload/StreamTransferManager.java
@@ -561,7 +561,7 @@ public class StreamTransferManager {
     @Override
     public String toString() {
         return String.format("[Manager uploading to %s/%s with id %s]",
-                bucketName, putKey, Utils.skipMiddle(uploadId, 21));
+                bucketName, putKey, Utils.skipMiddle(String.valueOf(uploadId), 21));
     }
 
     // These methods are intended to be overridden for more specific interactions with the AWS API.


### PR DESCRIPTION
Fixes #37.
The end result will be the uploadId being written as `null` if it is null, which is fine for the edge case this protects against. Better than throwing NPE, at least.