### PR TITLE
Upgrade to use awssdk v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.alexmojaki</groupId>
     <artifactId>s3-stream-upload</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5-SNAPSHOT</version>
 
     <name>S3 Stream Upload</name>
     <description>Manages streaming of data to S3 without knowing the size beforehand and without keeping it all in
@@ -38,19 +38,26 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssooidc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.gaul</groupId>
-            <artifactId>s3proxy</artifactId>
-            <version>1.7.0</version>
-            <scope>test</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -63,9 +70,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.782</version>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -74,6 +81,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>2.0.16</slf4j.version>  <!-- Aug 2024 -->
+        <awssdk.version>2.27.24</awssdk.version>  <!-- Sep 2024 -->
     </properties>
 
     <build>
@@ -83,8 +92,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/alex/mojaki/s3upload/MultiPartOutputStream.java
+++ b/src/main/java/alex/mojaki/s3upload/MultiPartOutputStream.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.io.OutputStream;
 import java.util.concurrent.BlockingQueue;
 
-import static com.amazonaws.services.s3.internal.Constants.MB;
+import static alex.mojaki.s3upload.StreamTransferManager.MB;
 
 /**
  * An {@code OutputStream} which packages data written to it into discrete {@link StreamPart}s which can be obtained

--- a/src/main/java/alex/mojaki/s3upload/StreamPart.java
+++ b/src/main/java/alex/mojaki/s3upload/StreamPart.java
@@ -1,6 +1,6 @@
 package alex.mojaki.s3upload;
 
-import com.amazonaws.util.Base64;
+import software.amazon.awssdk.utils.BinaryUtils;
 
 import java.io.InputStream;
 
@@ -40,7 +40,7 @@ class StreamPart {
     }
 
     public String getMD5Digest() {
-        return Base64.encodeAsString(stream.getMD5Digest());
+        return BinaryUtils.toBase64(stream.getMD5Digest());
     }
 
     @Override


### PR DESCRIPTION
Addtionally upgraded sl4fj, java, and simplified test execution against S3.

Thank you @alexmojaki for your library. It provided a great solution and starting point to solve the creation of a large .zip from S3 files and stream the resulting .zip (of unknown size) back.

The ability to test directly against S3 is vitally important to ensure that the changes are working correctly and to assure that this library is safe to use. This testing uncovered an interesting detail that the eTag in awssdk v2 are surrounded by double quotes.

I took a look at jclouds, s3proxy, etc. and while they look interesting I did not have enough time to figure them out and I was also concerned by the lack of activity in jclouds. Hence I figured that for future users, the easiest approach would be to remove them altogether and allow those interested in running the tests to do so directly against S3.

Also thank you @alexwhiteoval for your PR. I reviewed it to ensure I didn't miss anything and you had a more elegant way to incorporate the customise* handlers.